### PR TITLE
0.951

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ An Element class describes one or more CSS classes applied to the element. A cla
 
 0.95 - added support for Inspector Hover mode which shows the outlines of each element on a page when using the Inspector
 
+0.951 - fixed translations to be rendered for multi-page widgets embedded with a primary and second language
+
 ## Installation
 
 ### Script Setup
@@ -221,20 +223,25 @@ Note that if EZ Wild Apricot Web Designer is enabled, one of the two languages w
 
 ### Support for embedded WildApricot widgets on 3rd party Content Management Systems
 
-If you are using the WildApricot widget code using iframes, use the ?secondLanguage argument at the end of widget URL to trigger translations to be loaded.
+If you are using the WildApricot widget code using iframes, use the ?primaryLanguage and ?secondLanguage query string at the end of widget URL to trigger translations to be loaded by a page that is hosting the widget.
 
-1. Alter the WildApricot widget code to support the ?secondLanguage widget.
-2. Embed the widget on the translated page on the 3rd party CMS. This works with systems like Drupal, Squarespace and WordPress.
+1. Alter the WildApricot widget code to support the ?primaryLanguage and ?secondLanguage widget.
+2. Embed the widget with ?primaryLanguage to be loaded on the primary language page(s) of the website.
+3. Embed the widget with ?secondLanguage to be loaded on the translated page(s) of the website. 
 
-Example code:
+This works with systems like Drupal, Squarespace and WordPress.
 
-For ENGLISH pages use the default language widget:
+Example code for ENGLISH as a primary language, and FRENCH as a second language:
+
+For all ENGLISH pages add the ?primaryLanguage query string to the src="" part of the widget:
+
 ```html
-<iframe width='750px' height='400px' frameborder='no' src='https://mysite.wildapricot.org/widget/join-us' onload='tryToEnableWACookies("https://mysite.wildapricot.org");' ></iframe>
+<iframe width='750px' height='400px' frameborder='no' src='https://mysite.wildapricot.org/widget/join-us?primaryLanguage' onload='tryToEnableWACookies("https://mysite.wildapricot.org");' ></iframe>
 <script  type="text/javascript" language="javascript" src="https://mysite.wildapricot.org/Common/EnableCookies.js" ></script>
 ```
 
-For FRENCH pages add  the ?secondLanguage widget: 
+For all FRENCH pages add the ?secondLanguage query string to the src="" part of the widget:
+ 
 ```html
 <iframe width='750px' height='400px' frameborder='no' src='https://mysite.wildapricot.org/widget/join-us/?secondLanguage' onload='tryToEnableWACookies("https://mysite.wildapricot.org");' ></iframe>
 <script  type="text/javascript" language="javascript" src="https://mysite.wildapricot.org/Common/EnableCookies.js" ></script>

--- a/WildApricotTextManager/wildapricot-textmanager.js
+++ b/WildApricotTextManager/wildapricot-textmanager.js
@@ -127,9 +127,11 @@ $(document).ready(function () {
 
     // Set language if keyword in URL
     if (window.location.href.indexOf("?secondLanguage") > -1) {
-      isFrameMultilingual = true;
-    } else {
-      isFrameMultilingual = false;
+      setIsMultilingual(true);
+      window.location.href = window.location.href.replace("?secondLanguage", "");
+    } if (window.location.href.indexOf("?primaryLanguage") > -1) {
+      setIsMultilingual(false);
+      window.location.href = window.location.href.replace("?primaryLanguage", "");
     }
 
   // Load only if Formstack isn't detected.
@@ -257,7 +259,7 @@ function log(text, logType = "") {
 
 function replaceText(data) {
   // Language Show/Hide Custom Content Block
-  if (isMultilingual() || isFrameMultilingual) {
+  if (isMultilingual()) {
     var replacement_text = data.second_language_text;
     $(alterativeLanguageClassName).show();
     $(primaryLanguageClassName).hide();

--- a/WildApricotTextManager/wildapricot-widget-textmanager.js
+++ b/WildApricotTextManager/wildapricot-widget-textmanager.js
@@ -21,16 +21,18 @@ $(document).ready(function () {
         waWidgetClass = waWidgetClass;
     }
 
-    // Check for language slug
+    // Check for slug
     if (window.location.href.indexOf("/" + alterativeLanguageSlug + "/") > -1) {
-        toggleWidgetLanguage();
+        // Modify iframe src URL to use second language
+        $(waWidgetClass).each(function () {
+            widgetURL = $(this).attr('src');
+            $(this).attr('src', widgetURL + "?secondLanguage");
+        });
+    } else {
+        // Modify iframe src URL to use primary language
+        $(waWidgetClass).each(function () {
+            widgetURL = $(this).attr('src');
+            $(this).attr('src', widgetURL + "?primaryLanguage");
+        });
     }
 });
-
-// Modify iframe src URL
-function toggleWidgetLanguage() {
-    $(waWidgetClass).each(function () {
-        widgetURL = $(this).attr('src');
-        $(this).attr('src', widgetURL + "?secondLanguage");
-    });
-}


### PR DESCRIPTION
Original widget translation only worked on initially loaded widget page.

Updated code to set `SecondLanguage` cookie based on url keyword

**Usage changes:**

When editing widget URL directly, widgets for primary language must include `?primaryLanguage`
Widget url for secondary language will continue to use `?secondaryLanguage`