### PR TITLE
Add FontAwesome Macros #107

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Function: googlefont
 ```
 
 ---
-# Additional Features
+# EZ Add-Ons
 ## **FontAwesome Icons**
 
 EZ Wild Apricot Web Designer makes it easy to insert FontAwesome icons by using macros. Simply [sign up for FontAwesome](https://fontawesome.com/start) and add the provided JavaScript code snippet to your WildApricot Global JavaScript settings.

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Function: googlefont
 
 EZ Wild Apricot Web Designer makes it easy to insert FontAwesome icons by using macros. Simply [sign up for FontAwesome](https://fontawesome.com/start) and add the provided JavaScript code snippet to your WildApricot Global JavaScript settings.
 
-To insert an icon, first find the name of the icon you wish to use here: [https://fontawesome.com/search?o=r&m=free&s=solid](https://fontawesome.com/search?o=r&m=free&s=solid). Next, add that icon name within the `[fa][/fa]` macro to any WildApricot content or headline gadget.
+To insert an icon, first find the name of the icon you wish to use here: [https://fontawesome.com/search?o=r&m=free&s=solid](https://fontawesome.com/search?o=r&m=free&s=solid). Next, add that icon name within the `[ez-fa][/ez-fa]` macro to any WildApricot content or headline gadget.
 
 You can copy the name of icon by clicking on the icon and copying the text above the icon:
 
@@ -280,7 +280,7 @@ You can copy the name of icon by clicking on the icon and copying the text above
 
 **EXAMPLE:**
 ```text
-Macro Text: [fa]home[/fa]
+Macro Text: [[ez-fa]home[/[ez-fa]
 Result: 🏠
 ```
 Currently, it is not yet possible to add FontAwesome icons to menus and buttons via the EZ WildApcito Website Editor inspector.

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Function: googlefont
 
 EZ Wild Apricot Web Designer makes it easy to insert FontAwesome icons by using macros. Simply [sign up for FontAwesome](https://fontawesome.com/start) and add the provided JS code to your Wild Apricot Global JavaScript settings.
 
-To insert and icon, first find the name if the icon you wish to use here: [https://fontawesome.com/search?o=r&m=free&s=solid](https://fontawesome.com/search?o=r&m=free&s=solid). Next, add that icon name within the `[fa][/fa]` macro.
+To insert an icon, first find the name of the icon you wish to use here: [https://fontawesome.com/search?o=r&m=free&s=solid](https://fontawesome.com/search?o=r&m=free&s=solid). Next, add that icon name within the `[fa][/fa]` macro.
 
 **EXAMPLE:**
 ```text

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ You can copy the name of icon by clicking on the icon and copying the text above
 
 **EXAMPLE:**
 ```text
-Macro Text: [[ez-fa]home[/[ez-fa]
+Macro Text: [ez-fa]home[/[ez-fa]
 Result: 🏠
 ```
 Currently, it is not yet possible to add FontAwesome icons to menus and buttons via the EZ WildApcito Website Editor inspector.
@@ -340,4 +340,4 @@ EZ WildApricot Web Designer is supported on the latest versions of Chrome, Safar
 
 2.0.3 - allow moving of WATM icon to the right or left 10/4/2022
 
-2.0.4 - add [fa] macro for adding FontAwesome glyphs into a WildApricot page 10/6/2022
+2.0.4 - add [ez-fa] macro for adding FontAwesome glyphs into a WildApricot page 10/6/2022

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ You can copy the name of icon by clicking on the icon and copying the text above
 Macro Text: [ez-fa]home[/[ez-fa]
 Result: 🏠
 ```
-Currently, it is not yet possible to add FontAwesome icons to menus and buttons via the EZ WildApcito Website Editor inspector.
+Currently, it is not yet possible to add FontAwesome icons to menus and buttons via the EZ WildApricot Web Designer inspector.
 
 ---
 # Browser Requirements

--- a/README.md
+++ b/README.md
@@ -269,16 +269,21 @@ Function: googlefont
 # Additional Features
 ## **FontAwesome Icons**
 
-EZ Wild Apricot Web Designer makes it easy to insert FontAwesome icons by using macros. Simply [sign up for FontAwesome](https://fontawesome.com/start) and add the provided JS code to your Wild Apricot Global JavaScript settings.
+EZ Wild Apricot Web Designer makes it easy to insert FontAwesome icons by using macros. Simply [sign up for FontAwesome](https://fontawesome.com/start) and add the provided JavaScript code snippet to your WildApricot Global JavaScript settings.
 
-To insert an icon, first find the name of the icon you wish to use here: [https://fontawesome.com/search?o=r&m=free&s=solid](https://fontawesome.com/search?o=r&m=free&s=solid). Next, add that icon name within the `[fa][/fa]` macro.
+To insert an icon, first find the name of the icon you wish to use here: [https://fontawesome.com/search?o=r&m=free&s=solid](https://fontawesome.com/search?o=r&m=free&s=solid). Next, add that icon name within the `[fa][/fa]` macro to any WildApricot content or headline gadget.
+
+You can copy the name of icon by clicking on the icon and copying the text above the icon:
+
+![image](https://user-images.githubusercontent.com/458134/194419479-4d128d7a-f8ed-4e82-bbc0-603bd2e4a565.png)
+
 
 **EXAMPLE:**
 ```text
 Macro Text: [fa]home[/fa]
 Result: 🏠
 ```
-In this current version, it is not let possible to add icons to menus and buttons via the EZ Editor.
+Currently, it is not yet possible to add FontAwesome icons to menus and buttons via the EZ WildApcito Website Editor inspector.
 
 ---
 # Browser Requirements
@@ -329,10 +334,10 @@ EZ WildApricot Web Designer is supported on the latest versions of Chrome, Safar
 
 2.0b1 - new inspector and configuration file editor, a view properties window including image color picker, support for unlimited languages, easy configuration file upload and preview of changes, rewritten in ECMAScript 6 (no more jQuery!) 8/13/2022
 
-2.0.1 - added a new function for adding a Google font (`googlefont`) and adding a link to a piece of text (`createlink`), added support for cookies to work better
+2.0.1 - added a new function for adding a Google font (`googlefont`) and adding a link to a piece of text (`createlink`), added support for cookies to work better 9/8/2022
 
-2.0.2 - bug fixes
+2.0.2 - bug fixes, minimized french.csv file 9/20/2022
 
-2.0.3 - allow moving of WATM icon to the right or left
+2.0.3 - allow moving of WATM icon to the right or left 10/4/2022
 
-2.0.4 - add macros for FontAwesome
+2.0.4 - add [fa] macro for adding FontAwesome glyphs into a WildApricot page 10/6/2022

--- a/README.md
+++ b/README.md
@@ -266,6 +266,21 @@ Function: googlefont
 ```
 
 ---
+# Additional Features
+## **FontAwesome Icons**
+
+EZ Wild Apricot Web Designer makes it easy to insert FontAwesome icons by using macros. Simply [sign up for FontAwesome](https://fontawesome.com/start) and add the provided JS code to your Wild Apricot Global JavaScript settings.
+
+To insert and icon, first find the name if the icon you wish to use here: [https://fontawesome.com/search?o=r&m=free&s=solid](https://fontawesome.com/search?o=r&m=free&s=solid). Next, add that icon name within the `[fa][/fa]` macro.
+
+**EXAMPLE:**
+```text
+Macro Text: [fa]home[/fa]
+Result: 🏠
+```
+In this current version, it is not let possible to add icons to menus and buttons via the EZ Editor.
+
+---
 # Browser Requirements
 EZ WildApricot Web Designer is supported on the latest versions of Chrome, Safari, Firefox and Edge. Older browsers like Internet Explorer on Windows are supported "best effort," without formal testing or 100% compatibility.
 
@@ -319,3 +334,5 @@ EZ WildApricot Web Designer is supported on the latest versions of Chrome, Safar
 2.0.2 - bug fixes
 
 2.0.3 - allow moving of WATM icon to the right or left
+
+2.0.4 - add macros for FontAwesome

--- a/WildApricotTextManager/scripts/functions.js
+++ b/WildApricotTextManager/scripts/functions.js
@@ -377,5 +377,5 @@ const loadCSS = (cssFiles) => {
 };
 
 const escapeRegExp = (string) => {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return string.replace(/[.*+?^${}()|[\]\\\/]/g, "\\$&");
 };

--- a/WildApricotTextManager/wildapricot-textmanager.js
+++ b/WildApricotTextManager/wildapricot-textmanager.js
@@ -242,6 +242,20 @@ function start(license) {
                   log(e, "Error");
                 }
               }
+              // FontAwesome
+              document.querySelectorAll("body *").forEach(function (el) {
+                let regex = /\[ez-fa]{1,}(.*?)\[\/ez-fa]{1,}/gi;
+                let faRegex = /(?<=\[ez-fa])([a-z0-9].*?)(?=\[\/ez-fa])/gi;
+                walkText(el, regex, "icon", function (node, match, offset) {
+                  let iconEl = document.createElement("i");
+                  iconEl.classList.add("fa-solid");
+                  while ((faIcon = faRegex.exec(match)) !== null) {
+                    if (faIcon !== undefined)
+                      iconEl.classList.add(`fa-${faIcon[0]}`);
+                  }
+                  return iconEl;
+                });
+              });
             },
             error: () => {
               log(`"${currentCSV}" not found`, "Error");
@@ -250,20 +264,6 @@ function start(license) {
         );
       }
     };
-
-    // FontAwesome
-    document.querySelectorAll("body *").forEach(function (el) {
-      let regex = /\[ez-fa]{1,}(.*?)\[\/ez-fa]{1,}/gi;
-      let faRegex = /(?<=\[ez-fa])([a-z0-9].*?)(?=\[\/ez-fa])/gi;
-      walkText(el, regex, "icon", function (node, match, offset) {
-        let iconEl = document.createElement("i");
-        iconEl.classList.add("fa-solid");
-        while ((faIcon = faRegex.exec(match)) !== null) {
-          if (faIcon !== undefined) iconEl.classList.add(`fa-${faIcon[0]}`);
-        }
-        return iconEl;
-      });
-    });
   }
 
   const showWATMIcon = (license) => {

--- a/WildApricotTextManager/wildapricot-textmanager.js
+++ b/WildApricotTextManager/wildapricot-textmanager.js
@@ -3,7 +3,7 @@ let watm_location = document.currentScript.src.substring(
   document.currentScript.src.lastIndexOf("/")
 );
 
-let watm_version = "2.03";
+let watm_version = "2.04";
 let watm_styles = "default";
 let watm_info_url = "https://newpathconsulting.com/watm";
 
@@ -59,11 +59,10 @@ function loadScripts() {
   var head = document.head;
   var script = document.createElement("script");
   script.type = "text/javascript";
-  script.src = `${
-    requiredScripts[loadedScripts].includes("http")
+  script.src = `${requiredScripts[loadedScripts].includes("http")
       ? ""
       : watm_location + "/scripts/"
-  }${requiredScripts[loadedScripts]}`;
+    }${requiredScripts[loadedScripts]}`;
   script.onreadystatechange = callback;
   script.onload = callback;
   loadedScripts++;
@@ -120,8 +119,8 @@ function start(license) {
       currentLanguage = getCurrentLanguage();
       currentLanguage =
         currentLanguage == "Default" ||
-        currentLanguage == null ||
-        currentLanguage == ""
+          currentLanguage == null ||
+          currentLanguage == ""
           ? languages[0].className
           : currentLanguage;
 
@@ -148,8 +147,7 @@ function start(license) {
 
     do_not_cache = false;
     Papa.parse(
-      `${watm_location}/config.csv${
-        do_not_cache === true ? "?time=" + Math.round(Date.now() / 1000) : ""
+      `${watm_location}/config.csv${do_not_cache === true ? "?time=" + Math.round(Date.now() / 1000) : ""
       }`,
       {
         download: true,
@@ -215,10 +213,9 @@ function start(license) {
       // Load selected language CSV
       if (currentCSV) {
         Papa.parse(
-          `${watm_location}/translations/${currentCSV}${
-            do_not_cache === true
-              ? "?time=" + Math.round(Date.now() / 1000)
-              : ""
+          `${watm_location}/translations/${currentCSV}${do_not_cache === true
+            ? "?time=" + Math.round(Date.now() / 1000)
+            : ""
           }`,
           {
             download: true,
@@ -250,6 +247,20 @@ function start(license) {
         );
       }
     };
+
+    // FontAwesome
+    document.querySelectorAll("body *").forEach(function (el) {
+      let regex = /\[fa]{1,}(.*?)\[\/fa]{1,}/gi;
+      let faRegex = /(?<=\[fa])([a-z0-9].*?)(?=\[\/fa])/gi;
+      walkText(el, regex, "icon", function (node, match, offset) {
+        let iconEl = document.createElement("i");
+        iconEl.classList.add("fa-solid")
+        while ((faIcon = faRegex.exec(match)) !== null) {
+          if (faIcon !== undefined) iconEl.classList.add(`fa-${faIcon[0]}`);
+        }
+        return iconEl;
+      });
+    });
   }
 
   const showWATMIcon = (license) => {
@@ -257,7 +268,7 @@ function start(license) {
       appendWATMBtn(
         license,
         !!document.getElementById("idWaAdminSwitcher") ||
-          (enable_public_editor && !isInEditMode())
+        (enable_public_editor && !isInEditMode())
       );
   };
 

--- a/WildApricotTextManager/wildapricot-textmanager.js
+++ b/WildApricotTextManager/wildapricot-textmanager.js
@@ -59,10 +59,11 @@ function loadScripts() {
   var head = document.head;
   var script = document.createElement("script");
   script.type = "text/javascript";
-  script.src = `${requiredScripts[loadedScripts].includes("http")
+  script.src = `${
+    requiredScripts[loadedScripts].includes("http")
       ? ""
       : watm_location + "/scripts/"
-    }${requiredScripts[loadedScripts]}`;
+  }${requiredScripts[loadedScripts]}`;
   script.onreadystatechange = callback;
   script.onload = callback;
   loadedScripts++;
@@ -119,8 +120,8 @@ function start(license) {
       currentLanguage = getCurrentLanguage();
       currentLanguage =
         currentLanguage == "Default" ||
-          currentLanguage == null ||
-          currentLanguage == ""
+        currentLanguage == null ||
+        currentLanguage == ""
           ? languages[0].className
           : currentLanguage;
 
@@ -147,7 +148,8 @@ function start(license) {
 
     do_not_cache = false;
     Papa.parse(
-      `${watm_location}/config.csv${do_not_cache === true ? "?time=" + Math.round(Date.now() / 1000) : ""
+      `${watm_location}/config.csv${
+        do_not_cache === true ? "?time=" + Math.round(Date.now() / 1000) : ""
       }`,
       {
         download: true,
@@ -213,9 +215,10 @@ function start(license) {
       // Load selected language CSV
       if (currentCSV) {
         Papa.parse(
-          `${watm_location}/translations/${currentCSV}${do_not_cache === true
-            ? "?time=" + Math.round(Date.now() / 1000)
-            : ""
+          `${watm_location}/translations/${currentCSV}${
+            do_not_cache === true
+              ? "?time=" + Math.round(Date.now() / 1000)
+              : ""
           }`,
           {
             download: true,
@@ -250,11 +253,11 @@ function start(license) {
 
     // FontAwesome
     document.querySelectorAll("body *").forEach(function (el) {
-      let regex = /\[fa]{1,}(.*?)\[\/fa]{1,}/gi;
-      let faRegex = /(?<=\[fa])([a-z0-9].*?)(?=\[\/fa])/gi;
+      let regex = /\[ez-fa]{1,}(.*?)\[\/ez-fa]{1,}/gi;
+      let faRegex = /(?<=\[ez-fa])([a-z0-9].*?)(?=\[\/ez-fa])/gi;
       walkText(el, regex, "icon", function (node, match, offset) {
         let iconEl = document.createElement("i");
-        iconEl.classList.add("fa-solid")
+        iconEl.classList.add("fa-solid");
         while ((faIcon = faRegex.exec(match)) !== null) {
           if (faIcon !== undefined) iconEl.classList.add(`fa-${faIcon[0]}`);
         }
@@ -268,7 +271,7 @@ function start(license) {
       appendWATMBtn(
         license,
         !!document.getElementById("idWaAdminSwitcher") ||
-        (enable_public_editor && !isInEditMode())
+          (enable_public_editor && !isInEditMode())
       );
   };
 


### PR DESCRIPTION
This update adds macros for inserting FontAwesome icons.

Members must supply their own FA JS embed code from  https://fontawesome.com/start

To insert an icon, first find the name of the icon you wish to use here: https://fontawesome.com/search?o=r&m=free&s=solid. Next, add that icon name within the `[fa][/fa]` macro.

EXAMPLE:

```text
Macro Text: [fa]home[/fa]
Result: 🏠
```

BENEFITS:
* No need to write or edit html - the maco is added in the WYSIWYG editor
* Inherits the font styling from the WA editor, including color and size

CURRENT LIMITATIONS:
* Currently does not work in the EZ Editor spreadsheet - so no adding to menus and buttons this way
* Only Free and Solid icons available.

DEMO: https://ezdesigner.wildapricot.org/icons